### PR TITLE
Fix broken aligned environment

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -89,7 +89,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.1"
+    version: "0.4.2"
   flutter_svg:
     dependency: transitive
     description:

--- a/lib/src/render/layout/eqn_array.dart
+++ b/lib/src/render/layout/eqn_array.dart
@@ -136,10 +136,10 @@ class RenderEqnArray extends RenderBox
     final colWidths = <double>[];
     final sizeMap = <RenderBox, Size>{};
     while (child != null) {
-      final childSize = child.getLayoutSize(infiniteConstraint, dry: dry);
-      sizeMap[child] = childSize;
+      Size childSize = Size.zero;
       if (child is RenderLine) {
         child.alignColWidth = null;
+        childSize = child.getLayoutSize(infiniteConstraint, dry: dry);
         final childColWidth = child.alignColWidth;
         if (childColWidth != null) {
           for (var i = 0; i < childColWidth.length; i++) {
@@ -156,11 +156,13 @@ class RenderEqnArray extends RenderBox
           nonAligningSizes.add(childSize);
         }
       } else {
+        childSize = child.getLayoutSize(infiniteConstraint, dry: dry);
         colWidths[0] = math.max(
           colWidths[0],
           childSize.width,
         );
       }
+      sizeMap[child] = childSize;
       child = (child.parentData as EqnArrayParentData).nextSibling;
     }
 

--- a/lib/src/render/layout/eqn_array.dart
+++ b/lib/src/render/layout/eqn_array.dart
@@ -217,7 +217,9 @@ class RenderEqnArray extends RenderBox
       child = childParentData.nextSibling;
     }
 
-    this.width = width;
+    if (!dry) {
+      this.width = width;
+    }
 
     return Size(width, vPos);
   }

--- a/lib/src/render/layout/line.dart
+++ b/lib/src/render/layout/line.dart
@@ -479,10 +479,12 @@ class RenderLine extends RenderBox
       this.caretOffsets.add(mainPos);
       child = childParentData.nextSibling;
     }
+
+    size = constraints.constrain(
+        Size(mainPos, maxHeightAboveBaseline + maxDepthBelowBaseline));
     this._overflow = mainPos - size.width;
 
-    return constraints.constrain(
-        Size(mainPos, maxHeightAboveBaseline + maxDepthBelowBaseline));
+    return size;
   }
 
   @override


### PR DESCRIPTION
### Description

Fixes wrong alignment of _aligned_ environment macro. That's regression after [dry layout support](https://github.com/simpleclub-extended/flutter_math_fork/pull/11) integration. In addition some other rough edges where polished.

### Broken case

|Before|After|
|-|-|
|<img width="234" alt="Screenshot 2021-10-15 at 21 56 17" src="https://user-images.githubusercontent.com/85223458/137546711-832647e4-48d8-4dd1-9c7d-c8217d908ca9.png">|<img width="237" alt="Screenshot 2021-10-15 at 21 53 29" src="https://user-images.githubusercontent.com/85223458/137546725-d71b8d30-9e5e-4916-b265-0cb3cd4f5ce4.png">|

