### PR TITLE
Remove deprecated TextSelectionOverlay.fadeDuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2
+
+* Removed deprecated `TextSelectionOverlay.fadeDuration`.
+
 ## 0.6.1
 
 * Fixed text selection (`SelectableMath`).

--- a/lib/src/widgets/selection/handle_overlay.dart
+++ b/lib/src/widgets/selection/handle_overlay.dart
@@ -57,7 +57,7 @@ class _MathSelectionHandleOverlayState extends State<MathSelectionHandleOverlay>
     super.initState();
 
     _controller = AnimationController(
-        duration: TextSelectionOverlay.fadeDuration, vsync: this);
+        duration: SelectionOverlay.fadeDuration, vsync: this);
 
     _controller.forward();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_math_fork
 description: Fast and high-quality TeX math equation rendering with pure Dart & Flutter. 
-version: 0.6.1
+version: 0.6.1+1
 homepage: https://github.com/simpleclub-extended/flutter_math_fork
 
 environment:


### PR DESCRIPTION
`TextSelectionOverlay.fadeDuration` is deprecated and replaced with `SelectionOverlay.fadeDuration`.

In the latest flutter beta release however, the field was completely removed by accident. See the following issue.

https://github.com/flutter/flutter/issues/100343