### PR TITLE
Text field Cursor replication node

### DIFF
--- a/lib/src/ast/nodes/cursor_node.dart
+++ b/lib/src/ast/nodes/cursor_node.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+import '../../../ast.dart';
+import '../../render/layout/line.dart';
+import '../syntax_tree.dart';
+
+/// Node displays vertical bar the size of [MathOptions.fontSize]
+/// to replicate a text edit field cursor
+class CursorNode extends LeafNode {
+  @override
+  BuildResult buildWidget(
+      MathOptions options, List<BuildResult?> childBuildResults) {
+    final baselinePart = 1 - options.fontMetrics.axisHeight / 2;
+    final height = options.fontSize * baselinePart;
+    final baselineDistance = height * baselinePart;
+    final cursor = Container(height: height, width: 1.5, color: options.color);
+    return BuildResult(
+        options: options,
+        widget: _BaselineDistance(
+          baselineDistance: baselineDistance,
+          child: cursor,
+        ));
+  }
+
+  @override
+  AtomType get leftType => AtomType.ord;
+
+  @override
+  Mode get mode => Mode.text;
+
+  @override
+  AtomType get rightType => AtomType.ord;
+
+  @override
+  bool shouldRebuildWidget(MathOptions oldOptions, MathOptions newOptions) =>
+      false;
+}
+
+/// This render object overrides the return value of
+/// [RenderProxyBox.computeDistanceToActualBaseline]
+///
+/// Used to align [CursorNode] properly in a [RenderLine] in respect to symbols
+class _BaselineDistance extends SingleChildRenderObjectWidget {
+  const _BaselineDistance({
+    Key? key,
+    required this.baselineDistance,
+    Widget? child,
+  }) : super(key: key, child: child);
+
+  final double baselineDistance;
+
+  @override
+  _BaselineDistanceBox createRenderObject(BuildContext context) =>
+      _BaselineDistanceBox(baselineDistance);
+}
+
+class _BaselineDistanceBox extends RenderProxyBox {
+  _BaselineDistanceBox(this.baselineDistance);
+
+  final double baselineDistance;
+
+  @override
+  double? computeDistanceToActualBaseline(TextBaseline baseline) =>
+      baselineDistance;
+}

--- a/lib/src/ast/nodes/cursor_node.dart
+++ b/lib/src/ast/nodes/cursor_node.dart
@@ -12,7 +12,7 @@ class CursorNode extends LeafNode {
   BuildResult buildWidget(
       MathOptions options, List<BuildResult?> childBuildResults) {
     final baselinePart = 1 - options.fontMetrics.axisHeight / 2;
-    final height = options.fontSize * baselinePart;
+    final height = options.fontSize * baselinePart * options.sizeMultiplier;
     final baselineDistance = height * baselinePart;
     final cursor = Container(height: height, width: 1.5, color: options.color);
     return BuildResult(

--- a/lib/src/parser/tex/functions.dart
+++ b/lib/src/parser/tex/functions.dart
@@ -21,8 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import '../../ast/syntax_tree.dart';
-import '../../ast/types.dart';
+import '../../../ast.dart';
+import 'functions/custom/cursor.dart';
 import 'functions/katex_base.dart';
 import 'functions/katex_ext.dart';
 import 'parser.dart';
@@ -82,4 +82,6 @@ extension RegisterFunctionExt on Map<String, FunctionSpec> {
 
 final Map<String, FunctionSpec> functions = <String, FunctionSpec>{}
   ..registerFunctions(katexBaseFunctionEntries)
-  ..registerFunctions(katexExtFunctionEntries);
+  ..registerFunctions(katexExtFunctionEntries)
+  ..registerFunctions(cursorEntries);
+

--- a/lib/src/parser/tex/functions/custom/cursor.dart
+++ b/lib/src/parser/tex/functions/custom/cursor.dart
@@ -1,0 +1,10 @@
+import '../../../../../tex.dart';
+import '../../../../ast/nodes/cursor_node.dart';
+import '../../functions.dart';
+
+const cursorEntries = {
+  ['\\cursor']: FunctionSpec(numArgs: 1, handler: _cursorHandler)
+};
+
+GreenNode _cursorHandler(TexParser parser, FunctionContext context) =>
+    CursorNode();


### PR DESCRIPTION
Added a custom function `/cursor` that displays a vertical cursor view that can be used by [math_keyboard](https://pub.dev/packages/math_keyboard)

Previously a `|` sign has been used for this purpose. But it's alignment relative to other symbols wasn't correct due to large baseline of the symbol.

| Simple example. 1 line | Quadratic equation. Multiple cursors for quick demonstration |
|---|---|
| ![1](https://user-images.githubusercontent.com/31796433/162745554-bed97564-866f-47e8-85ec-4f27c94eae23.png) | ![3](https://user-images.githubusercontent.com/31796433/162745566-83186d11-e03c-4beb-8be5-24d195af1455.png) |

