### PR TITLE
Remove unnecessary null-aware operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3
+
+* Removed unnecessary null-aware operators. Bumped min Flutter version to `3.0.0` and Dart to `2.17.0`.
+
 ## 0.6.2
 
 * Added CursorNode

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,8 +6,6 @@ analyzer:
     implicit-dynamic: false
   exclude:
     - lib/**.freezed.dart
-  enable-experiment:
-    - non-nullable
 linter:
   rules:
     - prefer_relative_imports

--- a/lib/src/widgets/selectable.dart
+++ b/lib/src/widgets/selectable.dart
@@ -456,7 +456,7 @@ class InternalSelectableMathState extends State<InternalSelectableMath>
     super.didChangeDependencies();
     if (!_didAutoFocus && widget.autofocus) {
       _didAutoFocus = true;
-      SchedulerBinding.instance!.addPostFrameCallback((_) {
+      SchedulerBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
           FocusScope.of(context).autofocus(widget.focusNode!);
         }

--- a/lib/src/widgets/selection/overlay.dart
+++ b/lib/src/widgets/selection/overlay.dart
@@ -138,9 +138,9 @@ class MathSelectionOverlay {
     _handlesVisible = visible;
     // If we are in build state, it will be too late to update visibility.
     // We will need to schedule the build in next frame.
-    if (SchedulerBinding.instance!.schedulerPhase ==
+    if (SchedulerBinding.instance.schedulerPhase ==
         SchedulerPhase.persistentCallbacks) {
-      SchedulerBinding.instance!.addPostFrameCallback(_markNeedsBuild);
+      SchedulerBinding.instance.addPostFrameCallback(_markNeedsBuild);
     } else {
       _markNeedsBuild();
     }
@@ -190,9 +190,9 @@ class MathSelectionOverlay {
   /// that if you do call this during a build, the UI will not update until the
   /// next frame (i.e. many milliseconds later).
   void update() {
-    if (SchedulerBinding.instance!.schedulerPhase ==
+    if (SchedulerBinding.instance.schedulerPhase ==
         SchedulerPhase.persistentCallbacks) {
-      SchedulerBinding.instance!.addPostFrameCallback(_markNeedsBuild);
+      SchedulerBinding.instance.addPostFrameCallback(_markNeedsBuild);
     } else {
       _markNeedsBuild();
     }

--- a/lib/src/widgets/selection/overlay_manager.dart
+++ b/lib/src/widgets/selection/overlay_manager.dart
@@ -135,9 +135,9 @@ mixin SelectionOverlayManagerMixin<T extends StatefulWidget>
         debugRequiredFor: widget,
       );
       _selectionOverlay!.handlesVisible = _shouldShowSelectionHandles(cause);
-      if (SchedulerBinding.instance!.schedulerPhase ==
+      if (SchedulerBinding.instance.schedulerPhase ==
           SchedulerPhase.persistentCallbacks) {
-        SchedulerBinding.instance!
+        SchedulerBinding.instance
             .addPostFrameCallback((_) => _selectionOverlay!.showHandles());
       } else {
         _selectionOverlay!.showHandles();

--- a/lib/src/widgets/selection/web_selection_manager.dart
+++ b/lib/src/widgets/selection/web_selection_manager.dart
@@ -116,7 +116,7 @@ mixin WebSelectionControlsManagerMixin<T extends StatefulWidget>
         final transform = renderBox.getTransformTo(null);
         _textInputConnection?.setEditableSizeAndTransform(size, transform);
       }
-      SchedulerBinding.instance!
+      SchedulerBinding.instance
           .addPostFrameCallback((Duration _) => _updateSizeAndTransform());
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_math_fork
 description: Fast and high-quality TeX math equation rendering with pure Dart & Flutter. 
-version: 0.6.2
+version: 0.6.3
 homepage: https://github.com/simpleclub-extended/flutter_math_fork
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.6.2
 homepage: https://github.com/simpleclub-extended/flutter_math_fork
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=2.0.0'
+  sdk: '>=2.17.0 <3.0.0'
+  flutter: '>=3.0.0'
 
 dependencies:
   flutter:

--- a/test/widgets/selectable_test.dart
+++ b/test/widgets/selectable_test.dart
@@ -519,7 +519,7 @@ void main() {
 
       await tester.pump();
 
-      expect(RendererBinding.instance!.mouseTracker.debugDeviceActiveCursor(1),
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
           SystemMouseCursors.text);
     });
 


### PR DESCRIPTION
In Flutter 3, some calls are no longer nullable.

i.e.
```dart
SchedulerBinding.instance,
RendererBinding.instance
```

I also removed `non-nullable` experiment from `analysis_options.yaml`, which is no longer necessary.