### PR TITLE
fix: ignore root image during the hit test

### DIFF
--- a/lib/src/ast/nodes/sqrt.dart
+++ b/lib/src/ast/nodes/sqrt.dart
@@ -62,11 +62,16 @@ class SqrtNode extends SlotableNode {
           ),
           CustomLayoutId(
             id: _SqrtPos.surd,
-            child: LayoutBuilderPreserveBaseline(
-              builder: (context, constraints) => sqrtSvg(
-                minDelimiterHeight: constraints.minHeight,
-                baseWidth: constraints.minWidth,
-                options: options,
+            // we use IgnorePointer here to ignore root image during hit test,
+            // so 'SelectionManagerMixin.getRenderLineAtOffset' can find
+            // render lines in the base widget
+            child: IgnorePointer(
+              child: LayoutBuilderPreserveBaseline(
+                builder: (context, constraints) => sqrtSvg(
+                  minDelimiterHeight: constraints.minHeight,
+                  baseWidth: constraints.minWidth,
+                  options: options,
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
Currently we can't select expressions under the root:

![before](https://user-images.githubusercontent.com/25964451/176125074-7de578a4-68e7-46f6-ba4a-4673203fb43d.gif)


So this PR fixes it:

![after](https://user-images.githubusercontent.com/25964451/176125397-e1a08692-5825-4415-bd28-4278132cb5ad.gif)
