### PR TITLE
fix: :bug: update texMathFontOptions's boldsymbol fallback font family

### DIFF
--- a/lib/src/parser/tex/font.dart
+++ b/lib/src/parser/tex/font.dart
@@ -150,7 +150,7 @@ const texMathFontOptions = {
     fontShape: FontStyle.italic,
     fallback: [
       FontOptions(
-        fontFamily: 'Math',
+        fontFamily: 'Main',
         fontWeight: FontWeight.bold,
       )
     ],


### PR DESCRIPTION
update boldsymbol's fallback font option's Math to Main

when use number char with boldsymbol tag, the char's charmetrics dose not exist in charmetrics.
allows the char to use a different default font family.