### PR TITLE
removed unnecessary import flutter/rendering.dart

### DIFF
--- a/lib/src/ast/nodes/sqrt.dart
+++ b/lib/src/ast/nodes/sqrt.dart
@@ -2,7 +2,6 @@ import 'dart:math' as math;
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../render/constants.dart';


### PR DESCRIPTION
The import of 'package:flutter/rendering.dart' was unnecessary because all of the used elements are also provided by the import of 'package:flutter/material.dart'.