### PR TITLE
Fix method signature of gesture detector classes

### DIFF
--- a/lib/src/widgets/selection/gesture_detector_builder.dart
+++ b/lib/src/widgets/selection/gesture_detector_builder.dart
@@ -28,7 +28,7 @@ class MathSelectionGestureDetectorBuilder {
 
   /// Handler for [TextSelectionGestureDetector.onTapDown].
   @protected
-  void onTapDown(TapDownDetails details) {
+  void onTapDown(TapDragDownDetails details) {
     lastTapDownPosition = details.globalPosition;
     // The selection overlay should only be shown when the user is interacting
     // through a touch screen (via either a finger or a stylus). A mouse
@@ -95,7 +95,7 @@ class MathSelectionGestureDetectorBuilder {
   ///  * [TextSelectionGestureDetector.onSingleTapUp], which triggers
   ///    this callback.
   @protected
-  void onSingleTapUp(TapUpDetails details) {
+  void onSingleTapUp(TapDragUpDetails details) {
     if (delegate.selectionEnabled) {
       delegate.selectPositionAt(
           from: lastTapDownPosition!, cause: SelectionChangedCause.tap);
@@ -145,7 +145,7 @@ class MathSelectionGestureDetectorBuilder {
   }
 
   @protected
-  void onDoubleTapDown(TapDownDetails details) {
+  void onDoubleTapDown(TapDragDownDetails details) {
     if (delegate.selectionEnabled) {
       delegate.selectWordAt(
           offset: details.globalPosition, cause: SelectionChangedCause.tap);
@@ -154,7 +154,7 @@ class MathSelectionGestureDetectorBuilder {
   }
 
   @protected
-  void onDragSelectionStart(DragStartDetails details) {
+  void onDragSelectionStart(TapDragStartDetails details) {
     delegate.selectPositionAt(
       from: details.globalPosition,
       cause: SelectionChangedCause.drag,
@@ -162,16 +162,15 @@ class MathSelectionGestureDetectorBuilder {
   }
 
   @protected
-  void onDragSelectionEnd(DragEndDetails details) {
+  void onDragSelectionEnd(TapDragEndDetails details) {
     /* Subclass should override this method if needed. */
   }
 
   @protected
-  void onDragSelectionUpdate(
-      DragStartDetails startDetails, DragUpdateDetails updateDetails) {
+  void onDragSelectionUpdate(TapDragUpdateDetails details) {
     delegate.selectPositionAt(
-      from: startDetails.globalPosition,
-      to: updateDetails.globalPosition,
+      from: details.globalPosition,
+      to: details.globalPosition,
       cause: SelectionChangedCause.drag,
     );
   }

--- a/lib/src/widgets/selection/gesture_detector_builder_selectable.dart
+++ b/lib/src/widgets/selection/gesture_detector_builder_selectable.dart
@@ -36,7 +36,7 @@ class SelectableMathSelectionGestureDetectorBuilder
   }
 
   @override
-  void onSingleTapUp(TapUpDetails details) {
+  void onSingleTapUp(TapDragUpDetails details) {
     delegate.hide();
     if (delegate.selectionEnabled) {
       switch (Theme.of(delegate.context).platform) {


### PR DESCRIPTION
I'm not sure if this will affect any previous versions of flutter, but in the versions `Flutter 3.8.0-12.0.pre.15` and `Dart 3.0.0 (build 3.0.0-229.0.dev)` it is conflicting with the `TextSelectionGestureDetector` method signatures