### PR TITLE
support render MathML

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ SelectableMath(
 ## [Line Breaking](doc/line_breaking.md)
 
 ## Credits
-This project is possible thanks to the inspirations and resources from [the KaTeX Project](https://katex.org/), [MathJax](www.mathjax.org), [Zefyr](https://github.com/memspace/zefyr), and [CaTeX](https://github.com/simpleclub/CaTeX).
+This project is possible thanks to the inspirations and resources from [the KaTeX Project](https://katex.org/), [MathJax](www.mathjax.org), [Zefyr](https://github.com/memspace/zefyr), and [CaTeX](https://github.com/simpleclub/CaTeX), and [flutter_html_math](https://github.com/Sub6Resources/flutter_html).
 
 ## Goals
 - [x] : TeX math parsing (See [design doc](doc/design.md))
@@ -117,4 +117,4 @@ This project is possible thanks to the inspirations and resources from [the KaTe
 - [ ] : UnicodeMath parsing and encoding
 - [ ] : [UnicodeMath](https://www.unicode.org/notes/tn28/UTN28-PlainTextMath-v3.1.pdf)-style editing
 - [ ] : Breakable equations
-- [ ] : MathML parsing and encoding
+- [X] : MathML parsing and encoding

--- a/example/lib/demo.dart
+++ b/example/lib/demo.dart
@@ -37,7 +37,7 @@ class DemoPage extends StatelessWidget {
                         Center(
                           child: Text(
                             "Flutter Math's output",
-                            style: Theme.of(context).textTheme.headline6,
+                            style: Theme.of(context).textTheme.titleLarge,
                           ),
                         ),
                         Expanded(

--- a/example/lib/display.dart
+++ b/example/lib/display.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
 
 class DisplayMath extends StatelessWidget {

--- a/example/lib/equations.dart
+++ b/example/lib/equations.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
-import 'package:google_fonts/google_fonts.dart';
 
 const equations = [
   ['Solution of quadratic equation', r'x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}'],
@@ -38,10 +36,7 @@ class EquationsPage extends StatelessWidget {
                           children: [
                             ListTile(
                               title: Text(entry[0]),
-                              subtitle: SelectableText(
-                                entry[1],
-                                style: GoogleFonts.robotoMono(),
-                              ),
+                              subtitle: SelectableText(entry[1]),
                             ),
                             Container(
                               padding: const EdgeInsets.fromLTRB(1, 5, 1, 5),

--- a/example/lib/feature.dart
+++ b/example/lib/feature.dart
@@ -19,7 +19,7 @@ class FeaturePage extends StatelessWidget {
         children: <Widget>[
           Text(
             entries[i].key,
-            style: Theme.of(context).textTheme.headline3,
+            style: Theme.of(context).textTheme.displaySmall,
           ),
           GridView.builder(
             shrinkWrap: true,

--- a/example/lib/feature.dart
+++ b/example/lib/feature.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 import 'display.dart';
 import 'supported_data.dart';

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,79 +5,90 @@ packages:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: b003c3098049a51720352d219b0bb5f219b60fbfb68e7a4748139a06a5676515
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.8.2"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      url: "https://pub.dartlang.org"
+      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      url: "https://pub.dartlang.org"
+      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -89,12 +100,13 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.6.4"
+    version: "0.6.3+1"
   flutter_svg:
     dependency: transitive
     description:
       name: flutter_svg
-      url: "https://pub.dartlang.org"
+      sha256: a9feefaa78b0b685d2678552a0337912e3b6938f0148979b9e1618e64ccdb08d
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   flutter_test:
@@ -106,182 +118,208 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_tex
-      url: "https://pub.dartlang.org"
+      sha256: "8fa2079e8b338da05ceada989826bcf69ab3a9c767d710c21362dad16eca4166"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.3+4"
   google_fonts:
     dependency: "direct main"
     description:
       name: google_fonts
-      url: "https://pub.dartlang.org"
+      sha256: e70521755a6b08c6bde14ddae27dff5bf21010033888fc61da6c595f8a9f58c1
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.3"
   http:
     dependency: transitive
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.13.4"
+    version: "0.13.5"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
   markdown:
     dependency: transitive
     description:
       name: markdown
-      url: "https://pub.dartlang.org"
+      sha256: "01512006c8429f604eb10f9848717baeaedf99e991d14a50d540d9beff08e5c6"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.14"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.4"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "12307e7f0605ce3da64cf0db90e5fcab0869f3ca03f76be6bb2991ce0a55e82b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.9.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: dab22e92b41aa1255ea90ddc4bc2feaf35544fd0728e209638cad041a6e3928a
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   nested:
     dependency: transitive
     description:
       name: nested
-      url: "https://pub.dartlang.org"
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.3"
   path_drawing:
     dependency: transitive
     description:
       name: path_drawing
-      url: "https://pub.dartlang.org"
+      sha256: a19347362f85a45aadf6bdfa3c04f18ff6676c445375eecd6251f9e09b9db551
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   path_parsing:
     dependency: transitive
     description:
       name: path_parsing
-      url: "https://pub.dartlang.org"
+      sha256: "9508ebdf1c3ac3a68ad5fb15edab8b026382999f18f77352349e56fbd74183ac"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   path_provider:
     dependency: transitive
     description:
       name: path_provider
-      url: "https://pub.dartlang.org"
+      sha256: c7edf82217d4b2952b2129a61d3ad60f1075b9299e629e149a8d2e39c2e6aad4
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.14"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      url: "https://pub.dartlang.org"
+      sha256: da97262be945a72270513700a92b39dd2f4a54dad55d061687e2e37a6390366a
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.15"
-  path_provider_ios:
+    version: "2.0.25"
+  path_provider_foundation:
     dependency: transitive
     description:
-      name: path_provider_ios
-      url: "https://pub.dartlang.org"
+      name: path_provider_foundation
+      sha256: ad4c4d011830462633f03eb34445a45345673dfd4faf1ab0b4735fbd93b19183
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.10"
+    version: "2.2.2"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      url: "https://pub.dartlang.org"
+      sha256: "2ae08f2216225427e64ad224a24354221c2c7907e448e6e0e8b57b1eb9f10ad1"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.7"
-  path_provider_macos:
-    dependency: transitive
-    description:
-      name: path_provider_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.6"
+    version: "2.1.10"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "57585299a729335f1298b43245842678cb9f43a6310351b18fb577d6e33165ec"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.6"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      url: "https://pub.dartlang.org"
+      sha256: f53720498d5a543f9607db4b0e997c4b5438884de25b0f73098cc2671a51b130
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.5"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      url: "https://pub.dartlang.org"
+      sha256: "2ebb289dc4764ec397f5cd3ca9881c6d17196130a7d646ed022a0dd9c2e25a71"
+      url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
   platform:
     dependency: transitive
     description:
       name: platform
-      url: "https://pub.dartlang.org"
+      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "075f927ebbab4262ace8d0b283929ac5410c0ac4e7fc123c76429564facfb757"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   process:
     dependency: transitive
     description:
       name: process
-      url: "https://pub.dartlang.org"
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.4"
   provider:
     dependency: "direct main"
     description:
       name: provider
-      url: "https://pub.dartlang.org"
+      sha256: "8d7d4c2df46d6a6270a4e10404bfecb18a937e3e00f710c260d0a10415ce6b7b"
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.3"
   quiver:
     dependency: transitive
     description:
       name: quiver
-      url: "https://pub.dartlang.org"
+      sha256: "93982981971e812c94d4a6fa3a57b89f9ec12b38b6380cd3c1370c3b01e4580e"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   sky_engine:
@@ -293,121 +331,138 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.18"
   tuple:
     dependency: transitive
     description:
       name: tuple
-      url: "https://pub.dartlang.org"
+      sha256: fe3ae4f0dca3f9aac0888e2e0d117b642ce283a82d7017b54136290c0a3b0dd3
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   webview_flutter:
     dependency: transitive
     description:
       name: webview_flutter
-      url: "https://pub.dartlang.org"
+      sha256: "392c1d83b70fe2495de3ea2c84531268d5b8de2de3f01086a53334d8b6030a88"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.4"
   webview_flutter_android:
     dependency: transitive
     description:
       name: webview_flutter_android
-      url: "https://pub.dartlang.org"
+      sha256: "71003f78c3c1be4a652ce91c64846a2de3c097a182133a7f003807f2d4d31f47"
+      url: "https://pub.dev"
     source: hosted
     version: "2.8.14"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
       name: webview_flutter_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "60828a1ae6a1ac779895768b5567aea1157e1b0b58660ce67c6da30ae56694ec"
+      url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
   webview_flutter_plus:
     dependency: transitive
     description:
       name: webview_flutter_plus
-      url: "https://pub.dartlang.org"
+      sha256: bea8756ae096529254725def7c4a633851a785c7d49206e0817125ab02b14307
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.0+2"
   webview_flutter_wkwebview:
     dependency: transitive
     description:
       name: webview_flutter_wkwebview
-      url: "https://pub.dartlang.org"
+      sha256: "5285e2a22199aaddf67b01114893c47a718dd2d989d78453dc0174d7386f88f6"
+      url: "https://pub.dev"
     source: hosted
     version: "2.8.1"
   win32:
     dependency: transitive
     description:
       name: win32
-      url: "https://pub.dartlang.org"
+      sha256: a6f0236dbda0f63aa9a25ad1ff9a9d8a4eaaa5012da0dc59d21afdb1dc361ca4
+      url: "https://pub.dev"
     source: hosted
-    version: "2.7.0"
+    version: "3.1.4"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      url: "https://pub.dartlang.org"
+      sha256: ee1505df1426458f7f60aac270645098d318a8b4766d85fde75f76f2e21807d1
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.0+1"
+    version: "1.0.0"
   xml:
     dependency: transitive
     description:
       name: xml
-      url: "https://pub.dartlang.org"
+      sha256: ac0e3f4bf00ba2708c33fbabbbe766300e509f8c82dbd4ab6525039813f7e2fb
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=2.19.0 <4.0.0"
+  flutter: ">=3.3.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -57,14 +57,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.1"
-  crypto:
-    dependency: transitive
-    description:
-      name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.2"
   fake_async:
     dependency: transitive
     description:
@@ -73,22 +65,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
-  ffi:
-    dependency: transitive
-    description:
-      name: ffi
-      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
-  file:
-    dependency: transitive
-    description:
-      name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -122,30 +98,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.3+4"
-  google_fonts:
-    dependency: "direct main"
-    description:
-      name: google_fonts
-      sha256: e70521755a6b08c6bde14ddae27dff5bf21010033888fc61da6c595f8a9f58c1
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.3"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.13.5"
-  http_parser:
-    dependency: transitive
-    description:
-      name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.2"
   js:
     dependency: transitive
     description:
@@ -226,54 +178,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
-  path_provider:
-    dependency: transitive
-    description:
-      name: path_provider
-      sha256: c7edf82217d4b2952b2129a61d3ad60f1075b9299e629e149a8d2e39c2e6aad4
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.14"
-  path_provider_android:
-    dependency: transitive
-    description:
-      name: path_provider_android
-      sha256: da97262be945a72270513700a92b39dd2f4a54dad55d061687e2e37a6390366a
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.25"
-  path_provider_foundation:
-    dependency: transitive
-    description:
-      name: path_provider_foundation
-      sha256: ad4c4d011830462633f03eb34445a45345673dfd4faf1ab0b4735fbd93b19183
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.2"
-  path_provider_linux:
-    dependency: transitive
-    description:
-      name: path_provider_linux
-      sha256: "2ae08f2216225427e64ad224a24354221c2c7907e448e6e0e8b57b1eb9f10ad1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.10"
-  path_provider_platform_interface:
-    dependency: transitive
-    description:
-      name: path_provider_platform_interface
-      sha256: "57585299a729335f1298b43245842678cb9f43a6310351b18fb577d6e33165ec"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.6"
-  path_provider_windows:
-    dependency: transitive
-    description:
-      name: path_provider_windows
-      sha256: f53720498d5a543f9607db4b0e997c4b5438884de25b0f73098cc2671a51b130
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.5"
   petitparser:
     dependency: transitive
     description:
@@ -282,14 +186,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
-  platform:
-    dependency: transitive
-    description:
-      name: platform
-      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -298,14 +194,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.2.4"
   provider:
     dependency: "direct main"
     description:
@@ -383,14 +271,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.1"
   vector_math:
     dependency: transitive
     description:
@@ -439,22 +319,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.8.1"
-  win32:
-    dependency: transitive
-    description:
-      name: win32
-      sha256: a6f0236dbda0f63aa9a25ad1ff9a9d8a4eaaa5012da0dc59d21afdb1dc361ca4
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.4"
-  xdg_directories:
-    dependency: transitive
-    description:
-      name: xdg_directories
-      sha256: ee1505df1426458f7f60aac270645098d318a8b4766d85fde75f76f2e21807d1
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   xml:
     dependency: transitive
     description:
@@ -465,4 +329,4 @@ packages:
     version: "6.1.0"
 sdks:
   dart: ">=2.19.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.0.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.1"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: b36c7f7e24c0bdf1bf9a3da461c837d1de64b9f8beb190c9011d8c72a3dfd745
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.17.2"
   fake_async:
     dependency: transitive
     description:
@@ -76,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.6.3+1"
+    version: "0.6.4+1"
   flutter_svg:
     dependency: transitive
     description:
@@ -98,6 +106,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.3+4"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      sha256: "79d498e6d6761925a34ee5ea8fa6dfef38607781d2fa91e37523474282af55cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.2"
   js:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
 
   provider: any
   flutter_tex: ^4.0.3+4
-  google_fonts: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/ast/nodes/enclosure.dart
+++ b/lib/src/ast/nodes/enclosure.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
 

--- a/lib/src/ast/nodes/sqrt.dart
+++ b/lib/src/ast/nodes/sqrt.dart
@@ -2,7 +2,6 @@ import 'dart:math' as math;
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../render/constants.dart';

--- a/lib/src/ast/options.dart
+++ b/lib/src/ast/options.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/lib/src/encoder/matcher.dart
+++ b/lib/src/encoder/matcher.dart
@@ -3,7 +3,6 @@ import 'dart:math' as math;
 import 'package:collection/collection.dart';
 
 import '../ast/syntax_tree.dart';
-import '../utils/iterable_extensions.dart';
 
 abstract class Matcher {
   const Matcher();

--- a/lib/src/render/layout/eqn_array.dart
+++ b/lib/src/render/layout/eqn_array.dart
@@ -5,7 +5,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../ast/nodes/matrix.dart';
-import '../../utils/iterable_extensions.dart';
 import '../constants.dart';
 import '../utils/render_box_offset.dart';
 import '../utils/render_box_layout.dart';

--- a/lib/src/render/symbols/make_symbol.dart
+++ b/lib/src/render/symbols/make_symbol.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 
 import 'package:flutter/widgets.dart';
 

--- a/lib/src/render/utils/render_box_layout.dart
+++ b/lib/src/render/utils/render_box_layout.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 
 import 'package:flutter/rendering.dart';
 

--- a/lib/src/render/utils/render_box_offset.dart
+++ b/lib/src/render/utils/render_box_offset.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 
 import 'package:flutter/rendering.dart';
 

--- a/lib/src/utils/mathml_to_tex.dart
+++ b/lib/src/utils/mathml_to_tex.dart
@@ -1,0 +1,99 @@
+import 'package:html/dom.dart' as dom;
+
+String parseMathMLRecursive(dom.Node node, String parsed) {
+  if (node is dom.Element) {
+    List<dom.Element> nodeList = node.nodes.whereType<dom.Element>().toList();
+    if (node.localName == "math" ||
+        node.localName == "mrow" ||
+        node.localName == "mtr") {
+      for (var element in nodeList) {
+        parsed = parseMathMLRecursive(element, parsed);
+      }
+    }
+    // note: munder, mover, and munderover do not support placing braces and other
+    // markings above/below elements, instead they are treated as super/subscripts for now.
+    if ((node.localName == "msup" ||
+            node.localName == "msub" ||
+            node.localName == "munder" ||
+            node.localName == "mover") &&
+        nodeList.length == 2) {
+      parsed = parseMathMLRecursive(nodeList[0], parsed);
+      parsed =
+          "${parseMathMLRecursive(nodeList[1], "$parsed${node.localName == "msup" || node.localName == "mover" ? "^" : "_"}{")}}";
+    }
+    if ((node.localName == "msubsup" || node.localName == "munderover") &&
+        nodeList.length == 3) {
+      parsed = parseMathMLRecursive(nodeList[0], parsed);
+      parsed = "${parseMathMLRecursive(nodeList[1], "${parsed}_{")}}";
+      parsed = "${parseMathMLRecursive(nodeList[2], "$parsed^{")}}";
+    }
+    if (node.localName == "mfrac" && nodeList.length == 2) {
+      parsed = "${parseMathMLRecursive(nodeList[0], parsed + r"\frac{")}}";
+      parsed = "${parseMathMLRecursive(nodeList[1], "$parsed{")}}";
+    }
+    // note: doesn't support answer & intermediate steps
+    if (node.localName == "mlongdiv" && nodeList.length == 4) {
+      parsed = parseMathMLRecursive(nodeList[0], parsed);
+      parsed = "${parseMathMLRecursive(nodeList[2], parsed + r"\overline{)")}}";
+    }
+    if (node.localName == "msqrt") {
+      parsed = parsed + r"\sqrt{";
+      for (var element in nodeList) {
+        parsed = parseMathMLRecursive(element, parsed);
+      }
+      parsed = "$parsed}";
+    }
+    if (node.localName == "mroot" && nodeList.length == 2) {
+      parsed = "${parseMathMLRecursive(nodeList[1], parsed + r"\sqrt[")}]";
+      parsed = "${parseMathMLRecursive(nodeList[0], "$parsed{")}}";
+    }
+    if (node.localName == "mi" ||
+        node.localName == "mn" ||
+        node.localName == "mo") {
+      if (_mathML2Tex.keys.contains(node.text.trim())) {
+        parsed = parsed +
+            _mathML2Tex[
+                _mathML2Tex.keys.firstWhere((e) => e == node.text.trim())]!;
+      } else if (node.text.startsWith("&") && node.text.endsWith(";")) {
+        parsed = parsed +
+            node.text
+                .trim()
+                .replaceFirst("&", r"\")
+                .substring(0, node.text.trim().length - 1);
+      } else {
+        parsed = parsed + node.text.trim();
+      }
+    }
+    if (node.localName == 'mtable') {
+      String inner =
+          nodeList.map((e) => parseMathMLRecursive(e, '')).join(' \\\\');
+      parsed = '$parsed\\begin{matrix}$inner\\end{matrix}';
+    }
+    if (node.localName == "mtd") {
+      for (var element in nodeList) {
+        parsed = parseMathMLRecursive(element, parsed);
+      }
+      parsed = '$parsed & ';
+    }
+  }
+  return parsed;
+}
+
+Map<String, String> _mathML2Tex = {
+  "sin": r"\sin",
+  "sinh": r"\sinh",
+  "csc": r"\csc",
+  "csch": r"csch",
+  "cos": r"\cos",
+  "cosh": r"\cosh",
+  "sec": r"\sec",
+  "sech": r"\sech",
+  "tan": r"\tan",
+  "tanh": r"\tanh",
+  "cot": r"\cot",
+  "coth": r"\coth",
+  "log": r"\log",
+  "ln": r"\ln",
+  "{": r"\{",
+  "}": r"\}",
+};

--- a/lib/src/widgets/controller.dart
+++ b/lib/src/widgets/controller.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import '../ast/syntax_tree.dart';
 import '../utils/text_extension.dart';

--- a/lib/src/widgets/math.dart
+++ b/lib/src/widgets/math.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
 import '../ast/options.dart';

--- a/lib/src/widgets/math.dart
+++ b/lib/src/widgets/math.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:html/parser.dart';
 import 'package:provider/provider.dart';
+import 'package:html/dom.dart' as dom;
 
 import '../ast/options.dart';
 import '../ast/style.dart';
@@ -8,6 +10,7 @@ import '../ast/tex_break.dart';
 import '../parser/tex/parse_error.dart';
 import '../parser/tex/parser.dart';
 import '../parser/tex/settings.dart';
+import '../utils/mathml_to_tex.dart';
 import 'exception.dart';
 import 'mode.dart';
 import 'selectable.dart';
@@ -163,6 +166,61 @@ class Math extends StatelessWidget {
     );
   }
 
+  /// Math builder using a MathML string
+  ///
+  /// {@template flutter_math_fork.widgets.math.tex_builder}
+  /// [expression] will first be parsed under [settings]. Then the acquired
+  /// [SyntaxTree] will be built under a specific options. If [ParseException]
+  /// is thrown or a build error occurs, [onErrorFallback] will be displayed.
+  ///
+  /// You can control the options via [mathStyle] and [textStyle].
+  /// {@endtemplate}
+  ///
+  /// See alse:
+  ///
+  /// * [Math.mathStyle]
+  /// * [Math.textStyle]
+  factory Math.mathML(
+    String expression, {
+    Key? key,
+    MathStyle mathStyle = MathStyle.display,
+    TextStyle? textStyle,
+    OnErrorFallback onErrorFallback = defaultOnErrorFallback,
+    TexParserSettings settings = const TexParserSettings(),
+    double? textScaleFactor,
+    MathOptions? options,
+  }) {
+    return Math.mathMLFromDom(parse(expression));
+  }
+
+  /// Math builder using a Math Element
+  ///
+  /// {@template flutter_math_fork.widgets.math.tex_builder}
+  /// [expression] will first be parsed under [settings]. Then the acquired
+  /// [SyntaxTree] will be built under a specific options. If [ParseException]
+  /// is thrown or a build error occurs, [onErrorFallback] will be displayed.
+  ///
+  /// You can control the options via [mathStyle] and [textStyle].
+  /// {@endtemplate}
+  ///
+  /// See alse:
+  ///
+  /// * [Math.mathStyle]
+  /// * [Math.textStyle]
+  factory Math.mathMLFromDom(
+    dom.Node node, {
+    Key? key,
+    MathStyle mathStyle = MathStyle.display,
+    TextStyle? textStyle,
+    OnErrorFallback onErrorFallback = defaultOnErrorFallback,
+    TexParserSettings settings = const TexParserSettings(),
+    double? textScaleFactor,
+    MathOptions? options,
+  }) {
+    final expression = parseMathMLRecursive(node, r'');
+    return Math.tex(expression);
+  }
+
   @override
   Widget build(BuildContext context) {
     if (parseError != null) {
@@ -176,7 +234,7 @@ class Math extends StatelessWidget {
         effectiveTextStyle =
             DefaultTextStyle.of(context).style.merge(textStyle);
       }
-      if (MediaQuery.boldTextOverride(context)) {
+      if (MediaQuery.boldTextOf(context)) {
         effectiveTextStyle = effectiveTextStyle
             .merge(const TextStyle(fontWeight: FontWeight.bold));
       }

--- a/lib/src/widgets/selectable.dart
+++ b/lib/src/widgets/selectable.dart
@@ -1,10 +1,7 @@
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import 'package:tuple/tuple.dart';
 

--- a/lib/src/widgets/selection/gesture_detector_builder.dart
+++ b/lib/src/widgets/selection/gesture_detector_builder.dart
@@ -28,7 +28,7 @@ class MathSelectionGestureDetectorBuilder {
 
   /// Handler for [TextSelectionGestureDetector.onTapDown].
   @protected
-  void onTapDown(TapDownDetails details) {
+  void onTapDown(TapDragDownDetails details) {
     lastTapDownPosition = details.globalPosition;
     // The selection overlay should only be shown when the user is interacting
     // through a touch screen (via either a finger or a stylus). A mouse
@@ -95,7 +95,7 @@ class MathSelectionGestureDetectorBuilder {
   ///  * [TextSelectionGestureDetector.onSingleTapUp], which triggers
   ///    this callback.
   @protected
-  void onSingleTapUp(TapUpDetails details) {
+  void onSingleTapUp(TapDragUpDetails details) {
     if (delegate.selectionEnabled) {
       delegate.selectPositionAt(
           from: lastTapDownPosition!, cause: SelectionChangedCause.tap);
@@ -145,7 +145,7 @@ class MathSelectionGestureDetectorBuilder {
   }
 
   @protected
-  void onDoubleTapDown(TapDownDetails details) {
+  void onDoubleTapDown(TapDragDownDetails details) {
     if (delegate.selectionEnabled) {
       delegate.selectWordAt(
           offset: details.globalPosition, cause: SelectionChangedCause.tap);
@@ -153,8 +153,11 @@ class MathSelectionGestureDetectorBuilder {
     }
   }
 
+  late TapDragStartDetails startDetails;
+
   @protected
-  void onDragSelectionStart(DragStartDetails details) {
+  void onDragSelectionStart(TapDragStartDetails details) {
+    startDetails = details;
     delegate.selectPositionAt(
       from: details.globalPosition,
       cause: SelectionChangedCause.drag,
@@ -162,13 +165,12 @@ class MathSelectionGestureDetectorBuilder {
   }
 
   @protected
-  void onDragSelectionEnd(DragEndDetails details) {
+  void onDragSelectionEnd(TapDragEndDetails details) {
     /* Subclass should override this method if needed. */
   }
 
   @protected
-  void onDragSelectionUpdate(
-      DragStartDetails startDetails, DragUpdateDetails updateDetails) {
+  void onDragSelectionUpdate(TapDragUpdateDetails updateDetails) {
     delegate.selectPositionAt(
       from: startDetails.globalPosition,
       to: updateDetails.globalPosition,

--- a/lib/src/widgets/selection/gesture_detector_builder_selectable.dart
+++ b/lib/src/widgets/selection/gesture_detector_builder_selectable.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'gesture_detector_builder.dart';
@@ -36,7 +35,7 @@ class SelectableMathSelectionGestureDetectorBuilder
   }
 
   @override
-  void onSingleTapUp(TapUpDetails details) {
+  void onSingleTapUp(TapDragUpDetails details) {
     delegate.hide();
     if (delegate.selectionEnabled) {
       switch (Theme.of(delegate.context).platform) {

--- a/lib/src/widgets/selection/handle_overlay.dart
+++ b/lib/src/widgets/selection/handle_overlay.dart
@@ -1,10 +1,7 @@
 import 'dart:math' as math;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
-import 'package:flutter/widgets.dart';
 
 import 'overlay.dart';
 import 'overlay_manager.dart';

--- a/lib/src/widgets/selection/overlay.dart
+++ b/lib/src/widgets/selection/overlay.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/gestures.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -25,16 +24,8 @@ class MathSelectionOverlay {
     this.clipboardStatus,
   }) : _handlesVisible = handlesVisible {
     final overlay = Overlay.of(context, rootOverlay: true);
-    assert(
-      overlay != null,
-      'No Overlay widget exists above $context.\n'
-      'Usually the Navigator created by WidgetsApp provides the overlay. '
-      'Perhaps your '
-      'app content was created above the Navigator with the WidgetsApp '
-      'builder parameter.',
-    );
     _toolbarController =
-        AnimationController(duration: fadeDuration, vsync: overlay!);
+        AnimationController(duration: fadeDuration, vsync: overlay);
   }
 
   /// The context in which the selection handles should appear.
@@ -158,7 +149,7 @@ class MathSelectionOverlay {
               _buildHandle(context, MathSelectionHandlePosition.end)),
     ];
 
-    Overlay.of(context, rootOverlay: true, debugRequiredFor: debugRequiredFor)!
+    Overlay.of(context, rootOverlay: true, debugRequiredFor: debugRequiredFor)
         .insertAll(_handles!);
   }
 
@@ -175,7 +166,7 @@ class MathSelectionOverlay {
   void showToolbar() {
     assert(_toolbar == null);
     _toolbar = OverlayEntry(builder: _buildToolbar);
-    Overlay.of(context, rootOverlay: true, debugRequiredFor: debugRequiredFor)!
+    Overlay.of(context, rootOverlay: true, debugRequiredFor: debugRequiredFor)
         .insert(_toolbar!);
     _toolbarController.forward(from: 0.0);
   }

--- a/lib/src/widgets/selection/selection_manager.dart
+++ b/lib/src/widgets/selection/selection_manager.dart
@@ -1,7 +1,6 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../ast/syntax_tree.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_math_fork
 description: Fast and high-quality TeX math equation rendering with pure Dart & Flutter. 
-version: 0.6.3+1
+version: 0.6.4+1
 homepage: https://github.com/simpleclub-extended/flutter_math_fork
 
 environment:
@@ -16,6 +16,8 @@ dependencies:
   meta: ^1.3.0
   collection: ^1.15.0
   tuple: ^2.0.0
+  # Plugin for parsing html
+  html: ^0.15.0
 
 dev_dependencies:
   flutter_test:

--- a/test/encoder/matcher_test.dart
+++ b/test/encoder/matcher_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_math_fork/flutter_math.dart';
 import 'package:flutter_math_fork/src/ast/nodes/frac.dart';
 import 'package:flutter_math_fork/src/ast/nodes/symbol.dart';
 import 'package:flutter_math_fork/tex.dart';

--- a/test/helper.dart
+++ b/test/helper.dart
@@ -4,9 +4,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_math_fork/ast.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
-import 'package:flutter_math_fork/src/parser/tex/parse_error.dart';
 import 'package:flutter_math_fork/src/parser/tex/parser.dart';
-import 'package:flutter_math_fork/src/parser/tex/settings.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void testTexToMatchGoldenFile(

--- a/test/load_fonts.dart
+++ b/test/load_fonts.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
 

--- a/test/tex_break_test.dart
+++ b/test/tex_break_test.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_math_fork/ast.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
 import 'package:flutter_math_fork/src/ast/tex_break.dart';


### PR DESCRIPTION
1. Added Math.mathML constructor (/flutter_math_fork/lib/src/widgets/math.dart) on line 183
2. The specific MathML implementation refers to the following project:
https://github.com/Sub6Resources/flutter_html/blob/master/packages/flutter_html_math/lib/flutter_html_math.dart