### PR TITLE
Fixed color-update bug

### DIFF
--- a/lib/src/ast/nodes/symbol.dart
+++ b/lib/src/ast/nodes/symbol.dart
@@ -100,6 +100,7 @@ class SymbolNode extends LeafNode {
 
   @override
   bool shouldRebuildWidget(MathOptions oldOptions, MathOptions newOptions) =>
+      oldOptions.color != newOptions.color ||
       oldOptions.mathFontOptions != newOptions.mathFontOptions ||
       oldOptions.textFontOptions != newOptions.textFontOptions ||
       oldOptions.sizeMultiplier != newOptions.sizeMultiplier;


### PR DESCRIPTION
This PR fixes a bug where updated colors would not get applied to symbols, even after the color property of a MathOptions object is changed (until a full rebuild is called).

A `Math.tex()` in a `ToggleButtons` before the fix:
https://github.com/simpleclub-extended/flutter_math_fork/assets/66305960/bf283e38-1f92-40ce-af52-7f335aded200

After the fix:
https://github.com/simpleclub-extended/flutter_math_fork/assets/66305960/ce4b90d7-988b-451d-b461-afe3cc5849bd


