### PR TITLE
Fix simple null pointer exception

### DIFF
--- a/lib/src/widgets/math.dart
+++ b/lib/src/widgets/math.dart
@@ -187,7 +187,7 @@ class Math extends StatelessWidget {
       options = MathOptions(
         style: mathStyle,
         fontSize: effectiveTextStyle.fontSize! * textScaleFactor,
-        mathFontOptions: effectiveTextStyle.fontWeight != FontWeight.normal
+        mathFontOptions: effectiveTextStyle.fontWeight != FontWeight.normal && effectiveTextStyle.fontWeight != null
             ? FontOptions(fontWeight: effectiveTextStyle.fontWeight!)
             : null,
         logicalPpi: logicalPpi,

--- a/lib/src/widgets/selectable.dart
+++ b/lib/src/widgets/selectable.dart
@@ -242,7 +242,7 @@ class SelectableMath extends StatelessWidget {
         MathOptions(
           style: mathStyle,
           fontSize: effectiveTextStyle.fontSize! * textScaleFactor,
-          mathFontOptions: effectiveTextStyle.fontWeight != FontWeight.normal
+          mathFontOptions: effectiveTextStyle.fontWeight != FontWeight.normal && effectiveTextStyle.fontWeight != null
               ? FontOptions(fontWeight: effectiveTextStyle.fontWeight!)
               : null,
           logicalPpi: logicalPpi,


### PR DESCRIPTION
I see a null pointer exception happens, which is caused by `effectiveTextStyle.fontWeight` being null, thus this super simple PR fixes it.