### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   pana:
+    permissions:
+      contents: read
     timeout-minutes: 9
     runs-on: ubuntu-latest
     name: Configuration of ${{ matrix.package }}


### PR DESCRIPTION
Potential fix for [https://github.com/simpleclub/flutter_math/security/code-scanning/1](https://github.com/simpleclub/flutter_math/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the `pana` job. Since the job does not perform any write operations, we can restrict the permissions to `contents: read`, which is sufficient for most basic CI workflows. This change ensures that the `GITHUB_TOKEN` has the minimal permissions required to execute the job.

The `permissions` block should be added directly under the `pana` job definition, similar to how it is already defined for the `publish` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
