### PR TITLE
Fix: unbounded layout errors

### DIFF
--- a/lib/src/ast/nodes/left_right.dart
+++ b/lib/src/ast/nodes/left_right.dart
@@ -51,6 +51,9 @@ class LeftRightNode extends SlotableNode<EquationRowNode> {
         // Delimiter
         return LineElement(
           customCrossSize: (height, depth) {
+            if (!height.isFinite || !depth.isFinite) {
+              return const BoxConstraints(minHeight: 20.0);
+            }
             final delta = math.max(height - a, depth + a);
             final delimeterFullHeight = math.max(delta / 500 * delimiterFactor,
                 2 * delta - delimiterShorfall.toLpUnder(options));
@@ -61,7 +64,7 @@ class LeftRightNode extends SlotableNode<EquationRowNode> {
               : getSpacingSize(index == 0 ? AtomType.open : AtomType.rel,
                       body[(index + 1) ~/ 2].leftType, options.style)
                   .toLpUnder(options),
-          child: LayoutBuilderPreserveBaseline(
+          child: LayoutBuilder(
             builder: (context, constraints) => buildCustomSizedDelimWidget(
               index == 0
                   ? leftDelim

--- a/lib/src/ast/nodes/sqrt.dart
+++ b/lib/src/ast/nodes/sqrt.dart
@@ -65,7 +65,7 @@ class SqrtNode extends SlotableNode {
             // so 'SelectionManagerMixin.getRenderLineAtOffset' can find
             // render lines in the base widget
             child: IgnorePointer(
-              child: LayoutBuilderPreserveBaseline(
+              child: LayoutBuilder(
                 builder: (context, constraints) => sqrtSvg(
                   minDelimiterHeight: constraints.minHeight,
                   baseWidth: constraints.minWidth,
@@ -136,6 +136,7 @@ enum _SqrtPos {
 class SqrtLayoutDelegate extends CustomLayoutDelegate<_SqrtPos> {
   final MathOptions options;
   final MathOptions baseOptions;
+
   // final MathOptions indexOptions;
 
   SqrtLayoutDelegate({
@@ -143,6 +144,7 @@ class SqrtLayoutDelegate extends CustomLayoutDelegate<_SqrtPos> {
     required this.baseOptions,
     // required this.indexOptions,
   });
+
   var heightAboveBaseline = 0.0;
   var svgHorizontalPos = 0.0;
   var svgVerticalPos = 0.0;

--- a/lib/src/render/layout/layout_builder_baseline.dart
+++ b/lib/src/render/layout/layout_builder_baseline.dart
@@ -23,7 +23,6 @@ class LayoutBuilderPreserveBaseline
 class _RenderLayoutBuilderPreserveBaseline extends RenderBox
     with
         RenderObjectWithChildMixin<RenderBox>,
-        RenderObjectWithLayoutCallbackMixin,
         RenderConstrainedLayoutBuilder<BoxConstraints, RenderBox> {
   @override
   double? computeDistanceToActualBaseline(TextBaseline baseline) =>
@@ -60,7 +59,6 @@ class _RenderLayoutBuilderPreserveBaseline extends RenderBox
   @override
   void performLayout() {
     final constraints = this.constraints;
-    runLayoutCallback();
     if (child != null) {
       child!.layout(constraints, parentUsesSize: true);
       size = constraints.constrain(child!.size);

--- a/lib/src/render/layout/line.dart
+++ b/lib/src/render/layout/line.dart
@@ -19,6 +19,8 @@ class LineParentData extends ContainerBoxParentData<RenderBox> {
 
   bool alignerOrSpacer = false;
 
+  late BoxConstraints constraints;
+
   @override
   String toString() =>
       '${super.toString()}; canBreakBefore = $canBreakBefore; customSize = ${customCrossSize != null}; trailingMargin = $trailingMargin; alignerOrSpacer = $alignerOrSpacer';
@@ -340,7 +342,7 @@ class RenderLine extends RenderBox
       } else if (childParentData.alignerOrSpacer) {
         alignerAndSpacers.add(child);
       } else {
-        final childSize = child.getLayoutSize(infiniteConstraint, dry: dry);
+        final childSize = child.getLayoutSize(constraints.loosen(), dry: dry);
         sizeMap[child] = childSize;
         final distance = dry ? 0.0 : child.getDistanceToBaseline(textBaseline)!;
         maxHeightAboveBaseline = math.max(maxHeightAboveBaseline, distance);


### PR DESCRIPTION
### Summary

This PR fixes critical unbounded layout errors that occur when using complex math widgets like `\sqrt`, and `\left...\right` inside layouts with unbounded vertical constraints, such as `Column`, `ListView`, or `SingleChildScrollView`.

### The Problem

When a `Math` widget is placed in a vertically unbounded container, several internal components fail:

1.  `RenderLine`: Passes an `infiniteConstraint` to its children during the initial layout phase.
2.  `FracNode` & `LeftRightNode`: Their layout delegates (`FracLayoutDelegate`, `LeftRightNode`'s `buildWidget`) are not designed to handle infinite height constraints passed from `RenderLine`. They attempt calculations with `Infinity` or `null` values, leading to exceptions like:
    *   `_RenderLayoutBuilderPreserveBaseline object was given an infinite size during layout.`
    *   Type errors during layout calculations.